### PR TITLE
Defaults the api test helpers for terser usage

### DIFF
--- a/src/api/api-test-utils.ts
+++ b/src/api/api-test-utils.ts
@@ -15,6 +15,13 @@ interface MockErrorResponse<T> {
   body: T;
 }
 
+function defaultErrorResponse(): MockErrorResponse<string> {
+  return {
+    status: 500,
+    body: "An unknown error occured",
+  };
+}
+
 /**
  * Configures the mock server to return a JSON error.
  * @param verb The HTTP verb - "get" or "post"
@@ -40,9 +47,12 @@ export function jsonApiError<T>(
  */
 export function jsonGetApiError<T>(
   path: string,
-  mockResponse: MockErrorResponse<T>
+  mockResponse: Partial<MockErrorResponse<T>> = {}
 ): void {
-  return jsonApiError("get", path, mockResponse);
+  return jsonApiError("get", path, {
+    ...defaultErrorResponse(),
+    ...mockResponse,
+  });
 }
 
 /**
@@ -52,7 +62,10 @@ export function jsonGetApiError<T>(
  */
 export function jsonPostApiError<T>(
   path: string,
-  mockResponse: MockErrorResponse<T>
+  mockResponse: Partial<MockErrorResponse<T>> = {}
 ): void {
-  return jsonApiError("post", path, mockResponse);
+  return jsonApiError("post", path, {
+    ...defaultErrorResponse(),
+    ...mockResponse,
+  });
 }

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -1,5 +1,5 @@
+import { jsonGetApiError, jsonPostApiError } from "~/test-utils";
 import { fetchExampleApiResponse, postExampleApiResponse } from "./api";
-import { jsonGetApiError, jsonPostApiError } from "./api-test-utils";
 
 describe("api", () => {
   describe("fetchExampleApiResponse", () => {
@@ -9,12 +9,10 @@ describe("api", () => {
     });
 
     it("throws an exception for an error response", async () => {
-      jsonGetApiError("/hello-world", {
-        status: 500,
-        body: { message: "Unknown error" },
+      jsonGetApiError("/hello-world", { status: 404 });
+      await expect(fetchExampleApiResponse()).rejects.toMatchObject({
+        statusCode: 404,
       });
-
-      await expect(fetchExampleApiResponse()).rejects.toThrow(/500/);
     });
   });
 
@@ -25,10 +23,7 @@ describe("api", () => {
     });
 
     it("throws an exception for an error response", async () => {
-      jsonPostApiError("/hello-world", {
-        status: 500,
-        body: { message: "Unknown error" },
-      });
+      jsonPostApiError("/hello-world");
 
       await expect(postExampleApiResponse({ name: "testing" })).rejects.toThrow(
         /500/

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -2,9 +2,11 @@ import { API_URL } from "~/env";
 
 class ApiResponseError extends Error {
   response: Response;
+  statusCode: number;
 
   constructor(response: Response) {
     super(`API responded with ${response.status}`);
+    this.statusCode = response.status;
     this.response = response;
   }
 }

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -1,0 +1,1 @@
+export * from "~/api/api-test-utils";


### PR DESCRIPTION
I'm still on the fence if I would want to use these beyond the API
layer. On the one hand it is nice to have all tests call all the way
through to the api. On the other, it seems like mocking the API file
itself removes implementation knowledge from downstream tests. For
example, do tests for a component need to be concerned with urls
and status codes?