### PR TITLE
Adds a helper to run scripts within CI

### DIFF
--- a/.github/workflows/on-pr-to-main.yml
+++ b/.github/workflows/on-pr-to-main.yml
@@ -11,11 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: "Install dependencies"
-        run: npm install
-
       - name: "Run the linter"
-        run: npm run lint
+        run: ./scripts/ci npm run lint
 
       - name: "Run tests"
-        run: npm run test:ci
+        run: ./scripts/ci npm run test:ci

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+CMD="$*"
+
+if [ -z "$CMD" ]; then
+ echo "You must provide a command, for example: ./scripts/ci npm run test:ci"
+fi
+
+echo "Building a development Docker image"
+docker build -t react-starter-ci .
+
+echo "Running ${CMD} in react-starter-ci container"
+docker run --rm \
+    -v /app/node_modules \
+    -v "$(pwd)":/app \
+    react-starter-ci \
+    $CMD


### PR DESCRIPTION
This script sets up the Docker env for running in CI.
Although things generally run fine directly on the GitHub CI hosts,
it seems better to run in Docker so we have full control of the
environment.