### PR TITLE
Creates a `renderApp` test helper

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,22 +1,41 @@
 import React from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { GlobalErrorBoundary } from "~/components/global-error-boundary";
 import { Home } from "~/pages/home";
 
 const queryClient = new QueryClient();
 
+type AppRoutesProps = {
+  renderRoutes?: (children: JSX.Element) => JSX.Element;
+};
+
+/**
+ * Renders the top level routes of the app.
+ * Provides a prop to replace the underlying router implementation.
+ * The actual app will use the BrowserRouter (default value), but tests can
+ * swap this out for a MemoryRouter.
+ */
+export function AppRoutes({
+  renderRoutes = (routes) => <BrowserRouter>{routes}</BrowserRouter>,
+}: AppRoutesProps): JSX.Element {
+  return renderRoutes(
+    <Routes>
+      <Route path="*" element={<Home />} />
+    </Routes>
+  );
+}
+
+/**
+ * Renders the App including top level Providers.
+ */
 export function App(): JSX.Element {
   return (
     <React.StrictMode>
       <GlobalErrorBoundary>
         <QueryClientProvider client={queryClient}>
           <main>
-            <Router>
-              <Routes>
-                <Route path="*" element={<Home />} />
-              </Routes>
-            </Router>
+            <AppRoutes />
           </main>
         </QueryClientProvider>
       </GlobalErrorBoundary>

--- a/src/pages/home/home.test.tsx
+++ b/src/pages/home/home.test.tsx
@@ -1,22 +1,20 @@
-import React from "react";
 import { describe, it } from "vitest";
-import { jsonGetApiError, render, screen, waitFor } from "~/test-utils";
-import { Home } from "./home";
+import { jsonGetApiError, renderApp, screen, waitFor } from "~/test-utils";
 
 describe("<Home />", () => {
-  it("renders a loading screen initially", async () => {
-    render(<Home />);
+  it("renders a loading screen while the query loads", async () => {
+    renderApp("/");
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
 
-  it("renders the response when the query is done", async () => {
-    render(<Home />);
+  it("renders the response when the query is succeeds", async () => {
+    renderApp("/");
     await waitFor(() => expect(screen.getByText(/hello world$/i)));
   });
 
   it("renders an error if the query fails", async () => {
     jsonGetApiError("hello-world");
-    render(<Home />);
+    renderApp("/");
     await waitFor(() => expect(screen.getByText(/error/i)));
   });
 });

--- a/src/test-utils/test-utils.tsx
+++ b/src/test-utils/test-utils.tsx
@@ -8,31 +8,63 @@
  *
  * - Move the provider setup into a shared space which can then
  *      be reused by the <App /> component as well.
- * - Provide a `renderApp` which renders the entire app at a given
- *      route allowing you to test more in context.
  */
 import { render, RenderOptions } from "@testing-library/react";
 import React, { FC, ReactElement } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { AppRoutes } from "~/app";
 
+/**
+ * A query provider for react-query that is configured
+ * for unit tests.
+ */
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
+      cacheTime: 0,
       retry: false,
     },
   },
 });
 
+/**
+ * Applies all providers necessary for components running in a test env.
+ */
 const AllTheProviders: FC = ({ children }) => {
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 };
 
+/**
+ * Render the provided @param ui within the appropriate testing context.
+ * This is useful for testing a single component in isolation.
+ */
 const customRender = (
   ui: ReactElement,
   options?: Omit<RenderOptions, "wrapper">
 ) => render(ui, { wrapper: AllTheProviders, ...options });
 
+/**
+ * Render the top level `<App />` at an initial route.
+ * This helps to test a full page component in full context.
+ */
+const renderApp = (
+  initialPath: string,
+  options?: Omit<RenderOptions, "wrapper">
+) =>
+  render(
+    <AppRoutes
+      renderRoutes={(routes) => (
+        <MemoryRouter initialEntries={[initialPath]}>{routes}</MemoryRouter>
+      )}
+    />,
+    {
+      wrapper: AllTheProviders,
+      ...options,
+    }
+  );
+
 export * from "@testing-library/react";
-export { customRender as render };
+export { customRender as render, renderApp };


### PR DESCRIPTION
The goal is to have a test helper which can render the entire
app at a given route. This is useful when you want to test an
entire page full bootstrapped in the app.