### PR TITLE
Suppress console errors in tests

### DIFF
--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { fetchExampleApiResponse, postExampleApiResponse } from "./api";
-import { mocks, serverError, serverNotFound, useMockApi } from "~/test-utils";
+import {
+  mocks,
+  serverError,
+  serverNotFound,
+  suppressConsoleErrors,
+  useMockApi,
+} from "~/test-utils";
 
 describe("api", () => {
   describe("fetchExampleApiResponse", () => {
@@ -10,6 +16,7 @@ describe("api", () => {
     });
 
     it("throws an exception for an error response", async () => {
+      suppressConsoleErrors();
       useMockApi([mocks.fetchExampleApiResponse(serverNotFound())]);
       await expect(fetchExampleApiResponse()).rejects.toThrow(/404/);
     });
@@ -22,6 +29,7 @@ describe("api", () => {
     });
 
     it("throws an exception for an error response", async () => {
+      suppressConsoleErrors();
       useMockApi([mocks.postExampleApiResponse(serverError())]);
 
       await expect(postExampleApiResponse({ name: "testing" })).rejects.toThrow(

--- a/src/components/remote-data/remote-data-.test.tsx
+++ b/src/components/remote-data/remote-data-.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it } from "vitest";
-import { render, screen } from "~/test-utils";
+import { render, screen, suppressConsoleErrors } from "~/test-utils";
 import { RemoteData } from "./remote-data";
 
 function Loading(): JSX.Element {
@@ -18,7 +18,6 @@ function Data({
   name: string;
   isFetching?: boolean;
 }): JSX.Element {
-  console.log(isFetching);
   return (
     <div>
       hello {name} {isFetching ? "fetching" : ""}
@@ -43,6 +42,7 @@ describe("<RemoteData />", () => {
   });
 
   it("renders an error screen when there is an error", async () => {
+    suppressConsoleErrors();
     render(
       <RemoteData
         isLoading={false}

--- a/src/core/functions.ts
+++ b/src/core/functions.ts
@@ -1,0 +1,6 @@
+/**
+ * Empty function which can be useful as a default.
+ */
+export function noop(): void {
+  // do nothing
+}

--- a/src/pages/home/home.test.tsx
+++ b/src/pages/home/home.test.tsx
@@ -4,6 +4,7 @@ import {
   renderApp,
   screen,
   serverError,
+  suppressConsoleErrors,
   useMockApi,
   waitFor,
 } from "~/test-utils";
@@ -20,6 +21,7 @@ describe("<Home />", () => {
   });
 
   it("renders an error if the query fails", async () => {
+    suppressConsoleErrors();
     useMockApi([mocks.fetchExampleApiResponse(serverError())]);
     renderApp("/");
     await waitFor(() => expect(screen.getByText(/error/i)));

--- a/src/test-utils/test-utils.tsx
+++ b/src/test-utils/test-utils.tsx
@@ -13,7 +13,16 @@ import { render, RenderOptions } from "@testing-library/react";
 import React, { FC, ReactElement } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import { vi } from "vitest";
 import { AppRoutes } from "~/app";
+import { noop } from "~/core/functions";
+
+/**
+ * Creates a spy for `console.error` with a noop implementation.
+ */
+export function suppressConsoleErrors(): void {
+  vi.spyOn(console, "error").mockImplementation(noop);
+}
 
 /**
  * A query provider for react-query that is configured

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,8 @@
 import "@testing-library/jest-dom";
 import "cross-fetch/polyfill";
+
 import { afterAll, afterEach, beforeAll, vi } from "vitest";
+
 import { server } from "./src/mocks/node";
 
 /**
@@ -13,6 +15,11 @@ import { server } from "./src/mocks/node";
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
+
+/**
+ * Restore mocks between every test.
+ */
+afterEach(() => { vi.restoreAllMocks() });
 
 /**
  * Provide a mock of our env module during testing.


### PR DESCRIPTION
This is a very basic fix. I am wondering if in the future I could make a
custom describe/it block that includes this functionality instead?